### PR TITLE
Upgrade sharp to v0.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ Installation
 
 ### Dependencies
 
-Relax uses [sharp](https://github.com/lovell/sharp) to resize images so you'll need to install its dependencies. Fortunately they have great documentation on how to install them for each platform, you can check them [here](http://sharp.dimens.io/en/stable/install/).
+Relax uses [sharp](https://github.com/lovell/sharp) to resize images.
+If you're using OS X, you'll need to install its libvips dependency via `brew install homebrew/science/vips`.
+Full installation instructions are available [here](http://sharp.dimens.io/en/stable/install/).
 
 You'll also need [MongoDB](https://www.mongodb.org/).
 

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "rimraf": "^2.4.3",
     "semver": "^5.0.3",
     "serialize-javascript": "^1.1.2",
-    "sharp": "^0.11.4",
+    "sharp": "^0.12.0",
     "slug": "^0.9.1",
     "soundmanager2": "git://github.com/relax/SoundManager2.git",
     "superagent": "^1.4.0",


### PR DESCRIPTION
...as it now has no external runtime dependencies for 64-bit Linux/Windows.

I've also updated the installation details to save OS X users a click!