### PR TITLE
Fixes build issues with Windoze for a more consistent cross platform experience

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,13 @@
     "url": "https://github.com/relax/relax.git"
   },
   "scripts": {
-    "build": "NODE_ENV=production ./node_modules/.bin/webpack --output-public-path /public/js/ && cp -r assets/images/* public/images",
-    "start": "NODE_ENV=production ./node_modules/.bin/babel-node app",
-    "dev": "./node_modules/.bin/parallelshell 'npm run webpackServer' 'npm run watchServer'",
-    "watchServer": "./node_modules/.bin/nodemon -e js,jsx,json -w app.js -w lib -i lib/client -x './node_modules/webpack/bin/webpack.js --config ./webpack/webpack.node.config.js --progress && node build/app'",
-    "webpackServer": "node_modules/.bin/webpack-dev-server --config ./webpack/webpack.browser.config.js --inline --hot --progress --display-error-details",
-    "lint": "node_modules/.bin/eslint lib/** --quiet"
+    "build": "npm run env NODE_ENV=production && webpack --config ./webpack/webpack.browser.config.js && cp -r assets/images/* public/images",
+    "start": "npm run env NODE_ENV=production && node build/app",
+    "startDev": "node build/app",
+    "dev": "parallelshell \"npm run webpackServer\" \"npm run watchServer\"",
+    "watchServer": "nodemon -e js,jsx,json -w app.js -w lib -i lib/client -x \"webpack --config ./webpack/webpack.node.config.js && npm run startDev\"",
+    "webpackServer": "webpack-dev-server --config ./webpack/webpack.browser.config.js --inline --hot --quiet --display-error-details",
+    "lint": "eslint lib/** --quiet"
   },
   "dependencies": {
     "babel-polyfill": "^6.3.14",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "css-loader": "^0.23.1",
     "eslint": "^2.8.0",
     "eslint-config-airbnb": "^7.0.0",
+    "eslint-plugin-jsx-a11y": "^0.6.2",
     "eslint-plugin-react": "^4.2.2",
     "extract-text-webpack-plugin": "^0.9.1",
     "file-loader": "^0.8.4",


### PR DESCRIPTION
Tenative fix for #221 

This is working for me on 'Doze, will test on Mac shortly. I know npm scripts are the thing to do nowadays, but the crap involved here is why I like to define my build processes in code :smiling_imp:

- Got rid of pesky peerDep warnings
- Per [npm/npm #4040](https://github.com/npm/npm/issues/4040), uses non path-prefixed binaries as [npm-run-script](https://docs.npmjs.com/cli/run-script) does this for you.
- Created `startDev` script for ease of debugging
- Changed `NODE_ENV=production` to `npm run env` also mentioned in ^run-script docs.
- Key breakthrough was replacing all the `'` with `\"`. Windows *does not* like single quotes, at least in the npm script context.

Fail for having too long of a commit message.

PS, This is insanely awesome. I have dreamt of creating something like this (a react component CMS), and dynamic types too! Mad props. Would love to pitch in, will see what kind of bugs I can knock out.  
