### PR TITLE
Fixes prod build and cross platform environment issues

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -38,7 +38,7 @@ app.use(passport.initialize());
 app.use(passport.session());
 
 // Static files
-app.use(express.static('./public'));
+app.use(express.static(path.resolve('public')));
 app.use(['favicon.ico', '/images*', '/media*', '/css*', '/fonts*', '/js*'], (req, res) => {
   res.status(404).end();
 });

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/relax/relax.git"
   },
   "scripts": {
-    "build": "npm run env NODE_ENV=production && webpack --config ./webpack/webpack.browser.config.js && cp -r assets/images/* public/images",
+    "build": "npm run env NODE_ENV=production && webpack --config ./webpack/webpack.browser.config.js && webpack --config ./webpack/webpack.node.config.js",
     "start": "npm run env NODE_ENV=production && node build/app",
     "startDev": "node build/app",
     "dev": "parallelshell \"npm run webpackServer\" \"npm run watchServer\"",
@@ -96,6 +96,7 @@
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-0": "^6.3.13",
+    "copy-webpack-plugin": "^2.1.3",
     "css-loader": "^0.23.1",
     "eslint": "^2.8.0",
     "eslint-config-airbnb": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "url": "https://github.com/relax/relax.git"
   },
   "scripts": {
-    "build": "npm run env NODE_ENV=production && webpack --config ./webpack/webpack.browser.config.js && webpack --config ./webpack/webpack.node.config.js",
-    "start": "npm run env NODE_ENV=production && node build/app",
+    "build": "cross-env NODE_ENV=production webpack --config ./webpack/webpack.browser.config.js && cross-env NODE_ENV=production webpack --config ./webpack/webpack.node.config.js",
+    "start": "cross-env NODE_ENV=production node build/app",
     "startDev": "node build/app",
     "dev": "parallelshell \"npm run webpackServer\" \"npm run watchServer\"",
     "watchServer": "nodemon -e js,jsx,json -w app.js -w lib -i lib/client -x \"webpack --config ./webpack/webpack.node.config.js && npm run startDev\"",
@@ -97,6 +97,7 @@
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-0": "^6.3.13",
     "copy-webpack-plugin": "^2.1.3",
+    "cross-env": "^1.0.7",
     "css-loader": "^0.23.1",
     "eslint": "^2.8.0",
     "eslint-config-airbnb": "^7.0.0",
@@ -109,6 +110,7 @@
     "less-loader": "^2.2.2",
     "nodemon": "^1.8.1",
     "parallelshell": "^2.0.0",
+    "postcss-loader": "^0.9.1",
     "react-transform-catch-errors": "^1.0.2",
     "react-transform-hmr": "^1.0.2",
     "redbox-react": "^1.2.0",

--- a/webpack/webpack.browser.config.js
+++ b/webpack/webpack.browser.config.js
@@ -6,6 +6,8 @@ var config = require('../config');
 var NoErrorsPlugin = webpack.NoErrorsPlugin;
 var optimize = webpack.optimize;
 
+var PRODUCTION = process.env.NODE_ENV === 'production'
+
 var webpackConfig = module.exports = {
   entry: {
     admin: ['./lib/client/admin.js'],
@@ -15,7 +17,7 @@ var webpackConfig = module.exports = {
   output: {
     path: './public/js',
     filename: '[name].js',
-    publicPath: 'http://localhost:' + config.devPort + '/js/'
+    publicPath: 'http://localhost:' + config[PRODUCTION ? 'port' : 'devPort'] + '/js/'
   },
   resolve: {
     modulesDirectories: ['shared', 'node_modules'],
@@ -37,22 +39,24 @@ var webpackConfig = module.exports = {
         query: {
           cacheDirectory: true,
           presets: ['react', 'es2015', 'stage-0'],
-          plugins: [
-            ['transform-decorators-legacy'],
-            ['react-transform', {
-              transforms: [
-                {
-                  transform: 'react-transform-hmr',
-                  imports: ['react'],
-                  locals: ['module']
-                },
-                {
-                  transform: 'react-transform-catch-errors',
-                  imports: ['react', 'redbox-react']
-                }
-              ]
-            }]
-          ]
+          plugins: ['transform-decorators-legacy'],
+          env: {
+            development: [
+              ['react-transform', {
+                transforms: [
+                  {
+                    transform: 'react-transform-hmr',
+                    imports: ['react'],
+                    locals: ['module']
+                  },
+                  {
+                    transform: 'react-transform-catch-errors',
+                    imports: ['react', 'redbox-react']
+                  }
+                ]
+              }]
+            ]
+          }
         }
       },
       {
@@ -79,10 +83,10 @@ var webpackConfig = module.exports = {
 if (process.env.NODE_ENV === 'production') {
   webpackConfig.plugins.push(new ExtractTextPlugin('../css/[name].css'));
   webpackConfig.module.loaders.push({
-    test: /\.(css)$/,
+    test: /\.(css|less)$/,
     loader: ExtractTextPlugin.extract(
       'style-loader',
-      'css-loader?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!autoprefixer!postcss-loader',
+      'css-loader?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!autoprefixer!postcss-loader!less',
       {
         publicPath: '../css/'
       }

--- a/webpack/webpack.browser.config.js
+++ b/webpack/webpack.browser.config.js
@@ -1,5 +1,6 @@
 var webpack = require('webpack');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
+var CopyWebpackPlugin = require('copy-webpack-plugin');
 var config = require('../config');
 
 var NoErrorsPlugin = webpack.NoErrorsPlugin;
@@ -22,7 +23,10 @@ var webpackConfig = module.exports = {
   },
   plugins: [
     new optimize.OccurenceOrderPlugin(),
-    new optimize.CommonsChunkPlugin('common.js', ['admin', 'auth', 'public'])
+    new optimize.CommonsChunkPlugin('common.js', ['admin', 'auth', 'public']),
+    new CopyWebpackPlugin([
+      { context: 'assets', from: '**/*', to: '../' } // `to` is relative to output.path
+    ])
   ],
   module: {
     loaders: [
@@ -67,7 +71,8 @@ var webpackConfig = module.exports = {
   },
   devServer: {
     port: config.devPort,
-    contentBase: 'http://localhost:' + config.port
+    contentBase: 'http://localhost:' + config.port,
+    outputPath: 'public/js'
   }
 };
 

--- a/webpack/webpack.node.config.js
+++ b/webpack/webpack.node.config.js
@@ -13,7 +13,6 @@ fs.readdirSync('node_modules')
 
 module.exports = {
   entry: './app.js',
-  target: 'node',
   output: {
     path: path.join(__dirname, '..', 'build'),
     filename: 'app.js'
@@ -29,6 +28,16 @@ module.exports = {
       entryOnly: false
     })
   ],
+  target: 'node',
+  node: { // webpack strangely doesn't do this when you set `target: 'node'`
+    console: false,
+    global: false,
+    process: false,
+    Buffer: false,
+    __filename: false,
+    __dirname: false,
+    setImmediate: false
+  },
   devtool: 'sourcemap',
   module: {
     loaders: [
@@ -39,17 +48,21 @@ module.exports = {
         query: {
           cacheDirectory: true,
           presets: ['react', 'es2015', 'stage-0'],
-          plugins: [
-            ['transform-decorators-legacy'],
-            ['react-transform', {
-              transforms: [
-                {
-                  transform: 'react-transform-catch-errors',
-                  imports: ['react', 'redbox-react']
-                }
+          plugins: ['transform-decorators-legacy'],
+          env: {
+            development: {
+              plugins: [
+                ['react-transform', {
+                  transforms: [
+                    {
+                      transform: 'react-transform-catch-errors',
+                      imports: ['react', 'redbox-react']
+                    }
+                  ]
+                }]
               ]
-            }]
-          ]
+            }
+          }
         }
       },
       {


### PR DESCRIPTION
This gets things running well in production mode and is dependent on #235.

Had to scope the `react-transform` stuff to only development builds (we should checkout [`react-hot-loader@3`](https://github.com/gaearon/redux-devtools/commit/64f58b7010a1b2a71ad16716eb37ac1031f93915) at some point. Also, `express.static` wants an absolute path. Just be safe, I'm also explicitly telling webpack to not to mock anything in the node bundle (babel-polyfill still does all it's magic).

It turns out `npm run env` is buggy, and doesn't really work as you would expect.

Given the following:
```
SET NODE_ENV=production && echo $NODE_ENV
```
The `SET` command actually runs in a different shell, so `$NODE_ENV` is gone by the time you echo it. The solution isn't pretty, but works. Going to test this on Mac now. :racehorse: 

One thing to maybe think about down the road is support for setting env variables with something like [node-foreman](https://github.com/strongloop/node-foreman) or [dotenv](https://github.com/motdotla/dotenv). This would be more ideal in a heroku-like environment.