### PR TITLE
Upgrade sharp to v0.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "rimraf": "^2.4.3",
     "semver": "^5.0.3",
     "serialize-javascript": "^1.1.2",
-    "sharp": "^0.12.0",
+    "sharp": "^0.15.0",
     "slug": "^0.9.1",
     "soundmanager2": "git://github.com/relax/SoundManager2.git",
     "superagent": "^1.6.1",


### PR DESCRIPTION
Ola,

Resizing images with this new version is ~10-20% faster (CPU dependent), the quality is better as we're now using Lanzcos 3 by default and the implications of dealing with untrusted images is improved as *magick is no longer included.

I plan to flag the old v0.12.0 as deprecated in npm due to the security aspects of the latter point.

Cheers!