### PR TITLE
feat(seo): create tab for seo settings

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -10,6 +10,8 @@ import passport from 'passport';
 import path from 'path';
 import safeHtmlString from 'helpers/safe-html-string';
 import session from 'express-session';
+import _keys from 'lodash.keys';
+import _forEach from 'lodash.foreach';
 
 import config from '../../config';
 import middleware from './middleware';
@@ -60,9 +62,15 @@ app.use('/graphql', graphqlHTTP(req => ({
 })));
 
 app.use(async (req, res, next) => {
+
+  const metaSettings = {
+    'description': 'description', 'keywords': 'keywords',
+    'copyright':'copyright', 'robots':'robots', 'dctitle': 'DC.title'
+  };
+
   const settingsArr = await SettingModel
     .find({
-      _id: {$in: ['title', 'favicon']}
+      _id: {$in: ['title', 'favicon'].concat(_keys(metaSettings))}
     })
     .exec();
   const settings = parseSettings(settingsArr);
@@ -73,6 +81,18 @@ app.use(async (req, res, next) => {
       content: settings.title && safeHtmlString(settings.title) || 'Relax CMS'
     }
   ];
+
+  _forEach(metaSettings, ( (value, key) => {
+    res.locals.header.push(
+      {
+        tag: 'meta',
+        props:{
+          name: value,
+          content: settings[key] && safeHtmlString(settings[key]) || ''
+        }
+      }
+    );
+  }));
 
   if (process.env.NODE_ENV !== 'production') {
     res.baseScriptsURL = `http://localhost:${config.devPort}`;

--- a/lib/shared/routers/admin.js
+++ b/lib/shared/routers/admin.js
@@ -2,6 +2,7 @@ import {IndexRoute, Route} from 'react-router';
 
 import Admin from 'screens/admin';
 import AnalyticsSettings from 'screens/admin/screens/settings/screens/analytics';
+import SEOSettings from 'screens/admin/screens/settings/screens/seo';
 import Colors from 'screens/admin/screens/colors';
 import DataSchema from 'screens/admin/screens/schemas/screens/data';
 import DataSchemaEntry from 'screens/admin/screens/schemas/screens/data/screens/edit';
@@ -61,6 +62,7 @@ export default [
       <IndexRoute name='adminGeneralSettings' component={GeneralSettings} onEnter={authenticate} />
       <Route name='adminGoogleSettings' path='google' component={GoogleSettings} onEnter={authenticate} />
       <Route name='adminAnalyticsSettings' path='analytics' component={AnalyticsSettings} onEnter={authenticate} />
+      <Route name='adminSEOSettings' path='seo' component={SEOSettings} onEnter={authenticate} />
     </Route>
     <Route name='adminPages' path='pages' component={Pages} menu={PagesMenu}>
       <IndexRoute onEnter={authenticate} />

--- a/lib/shared/screens/admin/screens/settings/components/menu.jsx
+++ b/lib/shared/screens/admin/screens/settings/components/menu.jsx
@@ -14,6 +14,7 @@ export default class SettingsMenu extends Component {
 
   render () {
     const {onBack, pathname} = this.props;
+    const seoPath = '/admin/settings/seo';
     return (
       <div>
         <ListHeader
@@ -38,6 +39,12 @@ export default class SettingsMenu extends Component {
             label='Analytics'
             icon='nc-icon-outline ui-1_analytics-88'
             active={pathname === '/admin/settings/analytics'}
+          />
+          <Button
+            link={seoPath}
+            label='SEO'
+            icon='nc-icon-outline ui-1_zoom-split'
+            active={pathname === seoPath}
           />
         </Scrollable>
       </div>

--- a/lib/shared/screens/admin/screens/settings/screens/general/index.js
+++ b/lib/shared/screens/admin/screens/settings/screens/general/index.js
@@ -45,6 +45,7 @@ const options = [
       height: 114
     }
   }
+
 ];
 
 const settingsIds = ['title', 'frontpage', 'favicon', 'webclip'];

--- a/lib/shared/screens/admin/screens/settings/screens/seo/index.js
+++ b/lib/shared/screens/admin/screens/settings/screens/seo/index.js
@@ -1,0 +1,51 @@
+import Component from 'components/component';
+import Content from 'components/content';
+import React from 'react';
+import SettingsForm from 'components/settings-form';
+
+const options = [
+  {
+    label: 'Site Description',
+    type: 'String',
+    id: 'description',
+    default: ''
+  },
+  {
+    label: 'Copyright',
+    type: 'String',
+    id: 'copyright',
+    default: ''
+  },
+  {
+    label: 'Keywords',
+    type: 'String',
+    id: 'keywords',
+    default: ''
+  },
+  {
+    label: 'Robots',
+    type: 'String',
+    id: 'robots',
+    default: ''
+  },
+  {
+    label: 'DC Title',
+    type: 'String',
+    id: 'dctitle',
+    default: ''
+  }
+];
+
+const settingsIds = ['description', 'keywords', 'copyright', 'robots', 'dctitle'];
+
+export default class SEOSettingsContainer extends Component {
+  static propTypes = {};
+
+  render () {
+    return (
+      <Content noOffset>
+        <SettingsForm options={options} settingsIds={settingsIds} />
+      </Content>
+    );
+  }
+}

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "lodash.foreach": "^3.0.3",
     "lodash.get": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
     "lodash.intersection": "^4.2.0",
+    "lodash.keys": "^4.2.0",
     "lodash.merge": "^3.3.2",
     "lodash.omit": "^3.1.0",
     "lodash.sortby": "^3.1.5",


### PR DESCRIPTION
**Updates:**
Add SEO settings tab
Let me know if any changes should be made

See screenshot below to see what it looks like:

![seo view](https://i.imgur.com/eXNcHKz.png)


**Notes:**
- I wanted to make Description a Textarea but not sure how to do that.

**Future Considerations:**
- Make each property overridable per page
- Add tab for [Social Media meta tags](https://moz.com/blog/meta-data-templates-123) support

**Read more on SEO:**
- http://www.wordstream.com/meta-tags