### PR TITLE
fix(checkbox): fix settings option when handling booleans

### DIFF
--- a/lib/shared/actions/settings.js
+++ b/lib/shared/actions/settings.js
@@ -16,7 +16,7 @@ export function saveSettings (ids) {
     const settingsArr = [];
 
     forEach(ids, (id) => {
-      if (settings[id]) {
+      if (typeof settings[id] === 'boolean' || settings[id]) {
         settingsArr.push({
           _id: id,
           value: settings[id]

--- a/lib/shared/screens/admin/shared/components/input-options/checkbox/index.jsx
+++ b/lib/shared/screens/admin/shared/components/input-options/checkbox/index.jsx
@@ -2,12 +2,16 @@ import Component from 'components/component';
 import bind from 'decorators/bind';
 import cx from 'classnames';
 import React, {PropTypes} from 'react';
+import boolean from 'boolean';
 
 import styles from './index.less';
 
 export default class Checkbox extends Component {
   static propTypes = {
-    value: PropTypes.bool,
+    value: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.bool
+    ]),
     onChange: PropTypes.func.isRequired,
     disabled: PropTypes.bool,
     white: PropTypes.bool
@@ -19,12 +23,14 @@ export default class Checkbox extends Component {
     const {disabled, onChange, value} = this.props;
 
     if (!disabled && onChange) {
-      onChange(!value);
+      onChange(!boolean(value));
     }
   }
 
   render () {
     const {disabled, value, white} = this.props;
+    const checkboxValue = boolean(value);
+
     return (
       <span
         className={cx(
@@ -34,7 +40,7 @@ export default class Checkbox extends Component {
         )}
         onClick={this.toggle}
       >
-        {value && <i className='nc-icon-mini ui-1_check'></i>}
+        {checkboxValue && <i className='nc-icon-mini ui-1_check'></i>}
       </span>
     );
   }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "babel-polyfill": "^6.3.14",
     "bluebird": "^3.4.0",
     "body-parser": "^1.13.3",
+    "boolean": "^0.1.1",
     "classnames": "^2.1.3",
     "color-thief": "git+https://github.com/relax/color-thief.git",
     "colr": "^1.2.2",


### PR DESCRIPTION
Issue as outlined prevents a checkbox input type from saving a false value to the database.
This fix allows false values to be considered for storing.

The fix required the checkbox values to actually be booleans to work properly when handled by the reducer. Therefore, the option's value is/should be forced to type boolean when being set

Changelog:
- fix action when saving boolean settings
- handle checkbox warning when setting boolean value

resolves #354 