### PR TITLE
fix: undefined error when creating rich text property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ node_modules
 /public/
 dist/
 .tmp
+.DS_Store

--- a/lib/shared/helpers/truncate-html.js
+++ b/lib/shared/helpers/truncate-html.js
@@ -141,7 +141,7 @@ function getEndPosition ({string, tailPos, maxLength, total, options}) {
  * Truncate HTML string and keep tag safe.
  *
  * @method truncate
- * @param {String} string string needs to be truncated
+ * @param {String} string (required) string needs to be truncated
  * @param {Number} maxLength length of truncated string
  * @param {Object} options (optional)
  * @param {Boolean} [options.keepImageTag] flag to specify if keep image tag, false by default

--- a/lib/shared/helpers/truncate-html.js
+++ b/lib/shared/helpers/truncate-html.js
@@ -152,6 +152,8 @@ function getEndPosition ({string, tailPos, maxLength, total, options}) {
  * @return {String} truncated string
  */
 export default (_string, maxLength, _options) => {
+  if (!_string) { return EMPTY_STRING; }
+
   const items = [];
   const DEFAULT_SLOP = maxLength < 10 ? maxLength : 10;
   let total = 0;


### PR DESCRIPTION
**Issue:**
When I add a rich text property when creating a content type but no default is set, I get the following error. 

**Changelog**
- immediately return empty string if `_string` param is undefined to resolve error
- ignore `.DS_Store` for mac users

![err](https://i.imgur.com/jEx3I77.png)