### PR TITLE
update ui for edit content type screen

### DIFF
--- a/lib/shared/reducers/schema.js
+++ b/lib/shared/reducers/schema.js
@@ -119,12 +119,13 @@ export default function schemaReducer (state = defaultState, action = {}) {
       return Object.assign({}, state, {
         openedProperties: [...state.openedProperties, newId],
         data: Object.assign({}, state.data, {
-          properties: [...state.data.properties, {
+          properties: [{
             id: newId,
             title: 'New Property',
             type: 'String',
             required: false
-          }]
+          },
+          ...state.data.properties]
         })
       });
     }

--- a/lib/shared/reducers/schema.js
+++ b/lib/shared/reducers/schema.js
@@ -119,13 +119,12 @@ export default function schemaReducer (state = defaultState, action = {}) {
       return Object.assign({}, state, {
         openedProperties: [...state.openedProperties, newId],
         data: Object.assign({}, state.data, {
-          properties: [{
+          properties: [...state.data.properties, {
             id: newId,
             title: 'New Property',
             type: 'String',
             required: false
-          },
-          ...state.data.properties]
+          }]
         })
       });
     }

--- a/lib/shared/screens/admin/screens/schemas/shared/components/permissions/index.jsx
+++ b/lib/shared/screens/admin/screens/schemas/shared/components/permissions/index.jsx
@@ -15,6 +15,9 @@ export default class Permissions extends Component {
 
     return (
       <div className={styles.root}>
+        <div className={styles.header}>
+          <span>{'Permissions'}</span>
+        </div>
         <Permission
           value={readable}
           index='publicReadable'

--- a/lib/shared/screens/admin/screens/schemas/shared/components/permissions/index.less
+++ b/lib/shared/screens/admin/screens/schemas/shared/components/permissions/index.less
@@ -1,4 +1,16 @@
+@import '~styles/colors.less';
+
 .root {
   max-width: 550px;
   margin: 0 auto;
+}
+
+.header {
+  text-transform: uppercase;
+  font-size: 14px;
+  color: @adminText;
+  width: 100%;
+  text-align: center;
+  line-height: 70px;
+  padding: 10px 0;
 }

--- a/lib/shared/screens/admin/screens/schemas/shared/components/properties/properties.jsx
+++ b/lib/shared/screens/admin/screens/schemas/shared/components/properties/properties.jsx
@@ -21,11 +21,11 @@ export default class SchemaProperties extends Component {
     const {properties, addProperty, type} = this.props;
     return (
       <div className={styles.root}>
+        <button className={styles.addNew} onClick={addProperty}>
+          <i className="nc-icon-outline ui-1_circle-add"></i> Add new property
+        </button>
         {type === 'single' && singleFixedProperties.map(this.renderProperty, this)}
         {properties.map(this.renderProperty, this)}
-        <button className={styles.addNew} onClick={addProperty}>
-          Add new property
-        </button>
       </div>
     );
   }

--- a/lib/shared/screens/admin/screens/schemas/shared/components/properties/properties.jsx
+++ b/lib/shared/screens/admin/screens/schemas/shared/components/properties/properties.jsx
@@ -21,11 +21,11 @@ export default class SchemaProperties extends Component {
     const {properties, addProperty, type} = this.props;
     return (
       <div className={styles.root}>
+        {type === 'single' && singleFixedProperties.map(this.renderProperty, this)}
+        {properties.map(this.renderProperty, this)}
         <button className={styles.addNew} onClick={addProperty}>
           <i className="nc-icon-outline ui-1_circle-add"></i> Add new property
         </button>
-        {type === 'single' && singleFixedProperties.map(this.renderProperty, this)}
-        {properties.map(this.renderProperty, this)}
       </div>
     );
   }

--- a/lib/shared/screens/admin/screens/schemas/shared/components/properties/properties.less
+++ b/lib/shared/screens/admin/screens/schemas/shared/components/properties/properties.less
@@ -5,6 +5,7 @@
 }
 
 .addNew {
+  border: 1px dashed @adminBorders;
   text-transform: uppercase;
   font-size: 14px;
   color: @adminText;


### PR DESCRIPTION
It wasn't obvious how to add a new property mainly because my eyes were intuitively missing the `Add new property` link so added some ui changes

- move `Add new property` link above prop list
- prepend new prop in ui instead of append for noticeable reasons
- add plus icon to `Add new property` link
- add header for permissions section
- new permission header is also shown on the `new content type` page
 
### Page Without properties
![edit-page-without](https://i.imgur.com/99koNtX.png)

### Adding new prop
![edit-page-new-prop](https://i.imgur.com/OVMuIy1.png)

### Page with properties (default state)
![edit-page-props](https://i.imgur.com/1dMZMmj.png)

### New Content Type Page
![new-content-type](https://i.imgur.com/ReDI9oJ.png)
