### PR TITLE
Fixes proptype issues with ElementMenu, List, Search, and Autocomplete.

### DIFF
--- a/lib/shared/screens/admin/shared/components/page-builder/elements-menu/autocomplete.jsx
+++ b/lib/shared/screens/admin/shared/components/page-builder/elements-menu/autocomplete.jsx
@@ -9,7 +9,7 @@ export default class Autocomplete extends Component {
     autoFocus: React.PropTypes.bool,
     value: React.PropTypes.string.isRequired,
     onChange: React.PropTypes.func.isRequired,
-    suggestion: React.PropTypes.string
+    suggestion: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.bool]).isRequired
   };
 
   static defaultProps = {
@@ -60,6 +60,7 @@ export default class Autocomplete extends Component {
       <div className={styles.autocomplete}>
         <span onClick={this.focus}>{before}</span>
         <span
+          suppressContentEditableWarning
           ref='editable'
           className={styles.editable}
           onInput={this.onInput}

--- a/lib/shared/screens/admin/shared/components/page-builder/elements-menu/elements-menu.jsx
+++ b/lib/shared/screens/admin/shared/components/page-builder/elements-menu/elements-menu.jsx
@@ -20,7 +20,7 @@ export default class ElementsMenu extends Component {
   };
 
   static propTypes = {
-    symbols: PropTypes.array.isRequired,
+    symbols: PropTypes.array,
     pageBuilderActions: PropTypes.object.isRequired,
     elementsMenuOptions: PropTypes.object.isRequired,
     categories: PropTypes.array.isRequired

--- a/lib/shared/screens/admin/shared/components/page-builder/elements-menu/index.js
+++ b/lib/shared/screens/admin/shared/components/page-builder/elements-menu/index.js
@@ -9,7 +9,6 @@ import ElementsMenu from './elements-menu';
 
 @dataConnect(
   (state) => ({
-    symbols: state.symbols,
     elementsMenuOptions: state.pageBuilder.elementsMenuOptions,
     categories: state.pageBuilder.categories,
     categoriesCollapsed: state.pageBuilder.categoriesCollapsed
@@ -23,7 +22,7 @@ import ElementsMenu from './elements-menu';
 )
 export default class ElementsMenuContainer extends Component {
   static propTypes = {
-    symbols: PropTypes.object.isRequired,
+    symbols: PropTypes.array,
     pageBuilderActions: PropTypes.object.isRequired
   };
 

--- a/lib/shared/screens/admin/shared/components/page-builder/elements-menu/list.jsx
+++ b/lib/shared/screens/admin/shared/components/page-builder/elements-menu/list.jsx
@@ -13,9 +13,13 @@ export default class List extends Component {
     addElement: PropTypes.func.isRequired,
     addSymbol: PropTypes.func.isRequired,
     toggleCategory: PropTypes.func.isRequired,
-    symbols: PropTypes.object.isRequired,
-    categories: PropTypes.object.isRequired,
+    symbols: PropTypes.array,
+    categories: PropTypes.array.isRequired,
     categoriesCollapsed: PropTypes.object.isRequired
+  };
+
+  static defaultProps = {
+    symbols: []
   };
 
   toggleCategory (category, event) {

--- a/lib/shared/screens/admin/shared/components/page-builder/elements-menu/search.jsx
+++ b/lib/shared/screens/admin/shared/components/page-builder/elements-menu/search.jsx
@@ -16,10 +16,14 @@ export default class Search extends Component {
     addSymbol: PropTypes.func.isRequired,
     onSearchChange: PropTypes.func.isRequired,
     suggestions: PropTypes.array.isRequired,
-    suggestion: PropTypes.string.isRequired,
+    suggestion: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]).isRequired,
     search: PropTypes.string.isRequired,
-    symbols: PropTypes.object.isRequired,
-    categories: PropTypes.object.isRequired
+    symbols: PropTypes.array.isRequired,
+    categories: PropTypes.array.isRequired
+  };
+
+  static defaultProps = {
+    suggestion: false
   };
 
   componentDidMount () {


### PR DESCRIPTION
Fixes PropType mismatching. Also added the suppressContentEditableWarning in AutoComplete. In Search component the suggestion prop was both a bool and a string so added isOneOf for that prop.