### PR TITLE
Fixes error when you're on a new clean schema entry form and refresh.

### DIFF
--- a/lib/shared/screens/admin/screens/schemas/screens/data/shared/components/data-form-content/index.js
+++ b/lib/shared/screens/admin/screens/schemas/screens/data/shared/components/data-form-content/index.js
@@ -15,7 +15,7 @@ import DataSchemaForm from './form';
   }),
   (dispatch) => bindActionCreators(schemaEntryActions, dispatch),
   (props) => {
-    let result;
+    let result = {};
 
     if (props.entryId) {
       result = {


### PR DESCRIPTION
When the user is on a new clean Schema Entry Form and then refreshes an error occurs because if you aren't pulling back a draft result is null so it throws a red error screen. 