### PR TITLE
fixed username text reverse

### DIFF
--- a/lib/shared/screens/admin/shared/components/editable-title/index.jsx
+++ b/lib/shared/screens/admin/shared/components/editable-title/index.jsx
@@ -136,7 +136,6 @@ export default class EditableTitle extends Component {
             onInput={this.onChange}
             className={cx(styles.title, textClassName || styles.titleStyle)}
             contentEditable
-            dangerouslySetInnerHTML={{__html: this.state.editValue}}
             onKeyPress={this.keyPress}
             ref='input'
           />


### PR DESCRIPTION
refs #433 

If someone could let me know whether dangerouslySetInnerHTML is in there for a reason, please do! Otherwise, it looks like it's working as intended.